### PR TITLE
Enqueue out-of-band events

### DIFF
--- a/common/src/cljx/enoki/event.cljx
+++ b/common/src/cljx/enoki/event.cljx
@@ -5,7 +5,8 @@
 ;; should generally return the updated state, though return values may be
 ;; disregarded for some types of event (e.g. `:render`).
 
-(ns enoki.event)
+(ns enoki.event
+  (:require [enoki.util :as util]))
 
 (def subscribers
   "Map event types to subscribers (functions)"
@@ -22,3 +23,33 @@
   (reduce (fn [state handler] (apply handler state type args))
           state
           (@subscribers type)))
+
+(defn broadcast-all
+  "Broadcast a seq of events, each a pair of type and args."
+  [state events]
+  (reduce (fn [state [type args]] (apply broadcast state type args))
+          state
+          events))
+
+;; ## Out-of-band events
+;;
+;; Environment-specific events (e.g. key presses, window focus changes) can
+;; occur at any time. We need to deal with events at a predictable time during
+;; the main loop. Therefore, implementations enqueue these out-of-band events
+;; for subsequent re-broadcast.
+
+(def pending
+  "Out-of-band event queue, containing `[type args]` pairs."
+  (atom (util/queue)))
+
+(defn enqueue!
+  "Enqueue an event for subsequent rebroadcast."
+  [type & args]
+  (swap! pending conj [type args]))
+
+(defn drain!
+  "Drain the pending event queue."
+  []
+  (let [events @pending]
+    (reset! pending (util/queue))
+    events))

--- a/common/src/cljx/enoki/util.cljx
+++ b/common/src/cljx/enoki/util.cljx
@@ -1,0 +1,9 @@
+;; Various miscellaneous utilities
+
+(ns enoki.util)
+
+^:clj (defn queue [& args]
+        (into clojure.lang.PersistentQueue/EMPTY args))
+
+^:cljs (defn queue [& args]
+         (into cljs.core.PersistentQueue/EMPTY args))

--- a/common/test/cljx/enoki/engine_test.cljx
+++ b/common/test/cljx/enoki/engine_test.cljx
@@ -11,19 +11,6 @@
                    [enoki.graphics :as g])
          (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
 
-(deftest test-fire-key-events
-  (testing "handlers return updated state"
-    (e/subscribe! :key-pressed (fn [state type key]
-                                 (update-in state [:keys-pressed] conj key)))
-    (e/subscribe! :key-released (fn [state type key]
-                                  (update-in state [:keys-released] conj key)))
-    (let [initial-state {:keys-pressed #{}
-                         :keys-released #{}}
-          events [[:key-pressed :a] [:key-pressed :b] [:key-released :b] [:key-released :a]]
-          updated-state (engine/fire-key-events initial-state events)]
-      (is (= #{:a :b} (:keys-pressed updated-state)))
-      (is (= #{:a :b} (:keys-released updated-state))))))
-
 (defrecord DummyDisplay []
   g/Display
   (init-display! [_])

--- a/common/test/cljx/enoki/event_test.cljx
+++ b/common/test/cljx/enoki/event_test.cljx
@@ -1,10 +1,12 @@
 ^:clj (ns enoki.event-test
         (:require [enoki.event :as e])
-        (:use [clojure.test :only [deftest testing is]]))
+        (:use [clojure.test :only [deftest testing is]]
+              [enoki.util :only [queue]]))
 
 ^:cljs (ns enoki.event-test
          (:require [cemerick.cljs.test :as _]
                    [enoki.event :as e])
+         (:use [enoki.util :only [queue]])
          (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
 
 (deftest test-subscribe!
@@ -16,3 +18,27 @@
   (e/subscribe! :foo (fn [state type & args] (update-in state [type] conj :baz)))
   (e/subscribe! :foo (fn [state type & args] (update-in state [type] conj :bar)))
   (is (= {:foo '(:baz :bar)} (e/broadcast {} :foo))))
+
+(deftest broadcast-all
+  (let [received (atom [])
+        handler (fn [state type & args]
+                  (swap! received conj [state type args])
+                  state)]
+    (e/subscribe! :type-a handler)
+    (e/subscribe! :type-b handler)
+    (e/broadcast-all :state '((:type-a (:foo :bar))
+                              (:type-b (:baz :bla))))
+    (is (= ['(:state :type-a (:foo :bar))
+            '(:state :type-b (:baz :bla))]
+           @received))))
+
+(deftest test-enqueue!
+  (e/enqueue! :some-event :bar :baz)
+  (is (= @e/pending (queue '(:some-event (:bar :baz))))))
+
+(deftest test-drain!
+  (e/drain!)
+  (is (empty? @e/pending))
+  (e/enqueue! :some-event :bar :baz)
+  (is (= (queue '(:some-event (:bar :baz))) (e/drain!)))
+  (is (empty? @e/pending)))

--- a/common/test/cljx/enoki/keyboard_test.cljx
+++ b/common/test/cljx/enoki/keyboard_test.cljx
@@ -7,20 +7,13 @@
                   [enoki.keyboard :as k])
         (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
 
-(deftest test-consume-events!
-  (k/consume-events!)
-  (k/enqueue-event! :key-pressed :a)
-  (k/enqueue-event! :key-released :a)
-  (is (= [[:key-pressed :a] [:key-released :a]] (k/consume-events!)))
-  (is (= [] (k/consume-events!))))
-
-(deftest test-currently-pressed-keys
+(deftest test-updated-pressed-keys
   (let [events [[:key-pressed :foo]
                 [:key-released :foo]
                 [:key-pressed :bar]
                 [:key-pressed :foo]]]
-    (is (= #{:foo :bar} (k/currently-pressed-keys nil events)))))
+    (is (= #{:foo :bar} (k/update-pressed-keys nil events)))))
 
 (deftest test-persists-currently-pressed-keys
   (let [events [[:key-pressed :foo]]]
-    (is (= #{:foo :bar} (k/currently-pressed-keys #{:bar} events)))))
+    (is (= #{:foo :bar} (k/update-pressed-keys #{:bar} events)))))

--- a/common/test/cljx/enoki/util_test.cljx
+++ b/common/test/cljx/enoki/util_test.cljx
@@ -1,0 +1,13 @@
+^:clj (ns enoki.engine-test
+        (:require [enoki.util :as util])
+        (:use [clojure.test :only [deftest testing is]]))
+
+^:cljs (ns enoki.engine-test
+         (:require [cemerick.cljs.test :as test]
+                   [enoki.util :as util])
+         (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
+
+(deftest test-queue-creation
+  ;; XXX: do we need better tests here?
+  (is (not (nil? (util/queue))))
+  (is (not (nil? (util/queue :foo)))))

--- a/swing/src/enoki/swing.clj
+++ b/swing/src/enoki/swing.clj
@@ -1,8 +1,8 @@
 (ns enoki.swing
   (:require [clojure.string :as str]
             [seesaw.core :as seesaw]
+            [enoki.event :as event]
             [enoki.graphics.java2d :as gfx]
-            [enoki.keyboard :as kbd]
             [enoki.logging]
             [enoki.logging-macros :as log])
   (:import [java.awt.event KeyEvent]))
@@ -58,7 +58,7 @@
 
 (defn- handle-key-event [event-type e]
   (if-let [key-name (get key-names (.getKeyCode e))]
-    (kbd/enqueue-event! event-type key-name)
+    (event/enqueue! event-type key-name)
     (log/debug (format "unprocessable key event (%s): %s" event-type e))))
 
 (defn create-frame []

--- a/web/src/cljs/enoki/web.cljs
+++ b/web/src/cljs/enoki/web.cljs
@@ -3,7 +3,6 @@
             [clojure.string :as str]
             [enoki.event :as event]
             [enoki.graphics.canvas :as gfx]
-            [enoki.keyboard :as kbd]
             [enoki.logging :as logging])
   (:require-macros [enoki.logging-macros :as log]))
 
@@ -73,7 +72,7 @@
 (defn handle-key-event [event-type e]
   (if-let [key-name (get key-names (.-keyCode e))]
     (do
-      (kbd/enqueue-event! event-type key-name)
+      (event/enqueue! event-type key-name)
       (.preventDefault e))
     (log/info (format "unprocessable key event (%s): %s" event-type (.-keyCode e)))))
 


### PR DESCRIPTION
Provides an out-of-band event queue that gets broadcast as part of the main loop.

This is a generalisation of the keyboard event queue. Keyboard events are now implemented in terms of this interface.

This can be used for handling e.g. window focus events.
