### PR TITLE
Bump cljx to 0.3.0 and update usage accordingly

### DIFF
--- a/common/src/cljx/enoki/asset.cljx
+++ b/common/src/cljx/enoki/asset.cljx
@@ -1,14 +1,16 @@
 ;; Asset management
 
-^:clj (ns enoki.asset
-        (:require [enoki.asset-impl :as impl]
-                  [enoki.error])
-        (:use [enoki.error-macros :only [signal-error]]))
+#+clj
+(ns enoki.asset
+  (:require [enoki.asset-impl :as impl]
+            [enoki.error])
+  (:use [enoki.error-macros :only [signal-error]]))
 
-^:cljs (ns enoki.asset
-         (:require [enoki.asset-impl :as impl]
-                   [enoki.error])
-         (:use-macros [enoki.error-macros :only [signal-error]]))
+#+cljs
+(ns enoki.asset
+  (:require [enoki.asset-impl :as impl]
+            [enoki.error])
+  (:use-macros [enoki.error-macros :only [signal-error]]))
 
 ;; ## Loading
 

--- a/common/src/cljx/enoki/core.cljx
+++ b/common/src/cljx/enoki/core.cljx
@@ -5,12 +5,14 @@
 ;; FIXME: this should be false by default
 (def debug? (atom true))
 
-(defn ^:clj now
+#+clj
+(defn now
   "Return current timestamp in milliseconds."
   []
   (quot (System/nanoTime) 1000000))
 
-(defn ^:cljs now
+#+cljs
+(defn now
   "Return current timestamp in milliseconds."
   []
   (.getTime (new js/Date)))

--- a/common/src/cljx/enoki/engine.cljx
+++ b/common/src/cljx/enoki/engine.cljx
@@ -1,21 +1,23 @@
 ;; Core engine functionality.
 
-^:clj (ns enoki.engine
-        (:require [enoki.event :as e]
-                  [enoki.graphics :as g]
-                  [enoki.keyboard :as kbd]
-                  [enoki.logging]
-                  [enoki.logging-macros :as log])
-        (:use [enoki.core :only [now]]))
+#+clj
+(ns enoki.engine
+  (:require [enoki.event :as e]
+            [enoki.graphics :as g]
+            [enoki.keyboard :as kbd]
+            [enoki.logging]
+            [enoki.logging-macros :as log])
+  (:use [enoki.core :only [now]]))
 
-^:cljs (ns enoki.engine
-         (:require [goog.Timer :as timer]
-                   [enoki.event :as e]
-                   [enoki.graphics :as g]
-                   [enoki.keyboard :as kbd]
-                   [enoki.logging])
-         (:require-macros [enoki.logging-macros :as log])
-         (:use [enoki.core :only [now]]))
+#+cljs
+(ns enoki.engine
+  (:require [goog.Timer :as timer]
+            [enoki.event :as e]
+            [enoki.graphics :as g]
+            [enoki.keyboard :as kbd]
+            [enoki.logging])
+  (:require-macros [enoki.logging-macros :as log])
+  (:use [enoki.core :only [now]]))
 
 (defn update
   "Trigger an update of the game state. All handler functions registered for
@@ -65,9 +67,10 @@
 ;; put the running thread to sleep momentarily. The JavaScript equivalent is to
 ;; set a timeout that calls the next tick a moment into the future.
 
-(defn ^:clj loop-forever
-  "A naïve game loop implementation that repeatedly calls `tick', yielding
-   for 1ms between calls."
+#+clj
+(defn loop-forever
+  "A naïve game loop implementation that repeatedly calls `tick', yielding for
+   1ms between calls."
   [env]
   ;; We start a new thread to aid interactive development. This returns control
   ;; to the REPL immediately.
@@ -77,9 +80,10 @@
       (Thread.)
       (.start)))
 
-(defn ^:cljs loop-forever [env]
-  "A naïve game loop implementation that repeatedly calls `tick', yielding
-   for 1 ms between calls."
+#+cljs
+(defn loop-forever [env]
+  "A naïve game loop implementation that repeatedly calls `tick', yielding for
+   1ms between calls."
   (timer/callOnce #(loop-forever (tick env)) 1))
 
 (defn start

--- a/common/src/cljx/enoki/error.cljx
+++ b/common/src/cljx/enoki/error.cljx
@@ -2,19 +2,21 @@
   (:require [enoki.core]
             [enoki.logging]))
 
-^:clj (defn error
-        ([message]
-           (error message nil))
-        ([message throwable]
-           (if throwable
-             (Exception. message throwable)
-             (Exception. message))))
+#+clj
+(defn error
+  ([message]
+     (error message nil))
+  ([message throwable]
+     (if throwable
+       (Exception. message throwable)
+       (Exception. message))))
 
-^:cljs (defn error
-         ([message]
-            (error message nil))
-         ([message throwable]
-            (if throwable
-              ;; FIXME: is there a nicer way to display nested exceptions?
-              (js/Error. (format "%s: %s" message (.-message throwable)))
-              (js/Error. message))))
+#+cljs
+(defn error
+  ([message]
+     (error message nil))
+  ([message throwable]
+     (if throwable
+       ;; FIXME: is there a nicer way to display nested exceptions?
+       (js/Error. (format "%s: %s" message (.-message throwable)))
+       (js/Error. message))))

--- a/common/src/cljx/enoki/util.cljx
+++ b/common/src/cljx/enoki/util.cljx
@@ -2,8 +2,10 @@
 
 (ns enoki.util)
 
-^:clj (defn queue [& args]
-        (into clojure.lang.PersistentQueue/EMPTY args))
+#+clj
+(defn queue [& args]
+  (into clojure.lang.PersistentQueue/EMPTY args))
 
-^:cljs (defn queue [& args]
-         (into cljs.core.PersistentQueue/EMPTY args))
+#+cljs
+(defn queue [& args]
+  (into cljs.core.PersistentQueue/EMPTY args))

--- a/common/test/cljx/enoki/engine_test.cljx
+++ b/common/test/cljx/enoki/engine_test.cljx
@@ -1,15 +1,17 @@
-^:clj (ns enoki.engine-test
-        (:require [enoki.engine :as engine]
-                  [enoki.event :as e]
-                  [enoki.graphics :as g])
-        (:use [clojure.test :only [deftest testing is]]))
+#+clj
+(ns enoki.engine-test
+  (:require [enoki.engine :as engine]
+            [enoki.event :as e]
+            [enoki.graphics :as g])
+  (:use [clojure.test :only [deftest testing is]]))
 
-^:cljs (ns enoki.engine-test
-         (:require [cemerick.cljs.test :as test]
-                   [enoki.engine :as engine]
-                   [enoki.event :as e]
-                   [enoki.graphics :as g])
-         (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
+#+cljs
+(ns enoki.engine-test
+  (:require [cemerick.cljs.test :as test]
+            [enoki.engine :as engine]
+            [enoki.event :as e]
+            [enoki.graphics :as g])
+  (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
 
 (defrecord DummyDisplay []
   g/Display

--- a/common/test/cljx/enoki/event_test.cljx
+++ b/common/test/cljx/enoki/event_test.cljx
@@ -1,13 +1,15 @@
-^:clj (ns enoki.event-test
-        (:require [enoki.event :as e])
-        (:use [clojure.test :only [deftest testing is]]
-              [enoki.util :only [queue]]))
+#+clj
+(ns enoki.event-test
+  (:require [enoki.event :as e])
+  (:use [clojure.test :only [deftest testing is]]
+        [enoki.util :only [queue]]))
 
-^:cljs (ns enoki.event-test
-         (:require [cemerick.cljs.test :as _]
-                   [enoki.event :as e])
-         (:use [enoki.util :only [queue]])
-         (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
+#+cljs
+(ns enoki.event-test
+  (:require [cemerick.cljs.test :as _]
+            [enoki.event :as e])
+  (:use [enoki.util :only [queue]])
+  (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
 
 (deftest test-subscribe!
   (let [handler (constantly :updated-state)]

--- a/common/test/cljx/enoki/keyboard_test.cljx
+++ b/common/test/cljx/enoki/keyboard_test.cljx
@@ -1,11 +1,13 @@
-^:clj (ns enoki.keyboard-test
-        (:require [enoki.keyboard :as k])
-        (:use [clojure.test :only [deftest testing is]]))
+#+clj
+(ns enoki.keyboard-test
+  (:require [enoki.keyboard :as k])
+  (:use [clojure.test :only [deftest testing is]]))
 
-^:cljs (ns enoki.keyboard-test
-        (:require [cemerick.cljs.test :as _]
-                  [enoki.keyboard :as k])
-        (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
+#+cljs
+(ns enoki.keyboard-test
+  (:require [cemerick.cljs.test :as _]
+            [enoki.keyboard :as k])
+  (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
 
 (deftest test-updated-pressed-keys
   (let [events [[:key-pressed :foo]

--- a/common/test/cljx/enoki/util_test.cljx
+++ b/common/test/cljx/enoki/util_test.cljx
@@ -1,11 +1,13 @@
-^:clj (ns enoki.engine-test
-        (:require [enoki.util :as util])
-        (:use [clojure.test :only [deftest testing is]]))
+#+clj
+(ns enoki.engine-test
+  (:require [enoki.util :as util])
+  (:use [clojure.test :only [deftest testing is]]))
 
-^:cljs (ns enoki.engine-test
-         (:require [cemerick.cljs.test :as test]
-                   [enoki.util :as util])
-         (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
+#+cljs
+(ns enoki.engine-test
+  (:require [cemerick.cljs.test :as test]
+            [enoki.util :as util])
+  (:use-macros [cemerick.cljs.test :only [deftest testing is]]))
 
 (deftest test-queue-creation
   ;; XXX: do we need better tests here?

--- a/example/common/src/cljx/game/component.cljx
+++ b/example/common/src/cljx/game/component.cljx
@@ -1,10 +1,12 @@
 ;; Game-specific components
 
-^:clj (ns game.component
-        (:use [enoki.component-macros :only [defcomponent]]))
+#+clj
+(ns game.component
+  (:use [enoki.component-macros :only [defcomponent]]))
 
-^:cljs (ns game.component
-         (:use-macros [enoki.component-macros :only [defcomponent]]))
+#+cljs
+(ns game.component
+  (:use-macros [enoki.component-macros :only [defcomponent]]))
 
 (defcomponent position [x y]
   :x x, :y y)

--- a/example/common/src/cljx/game/main.cljx
+++ b/example/common/src/cljx/game/main.cljx
@@ -1,29 +1,31 @@
-^:clj (ns game.main
-        (:require [clojure.string :as str]
-                  [enoki.asset :as asset]
-                  [enoki.engine :as enoki]
-                  [enoki.entity :as entity]
-                  [enoki.event :as event]
-                  [enoki.graphics :as gfx]
-                  [enoki.logging]
-                  [enoki.logging-macros :as log]
-                  [game.component :as comp]
-                  [game.sprite :as sprite])
-        (:use [enoki.core :only [now]]))
+#+clj
+(ns game.main
+  (:require [clojure.string :as str]
+            [enoki.asset :as asset]
+            [enoki.engine :as enoki]
+            [enoki.entity :as entity]
+            [enoki.event :as event]
+            [enoki.graphics :as gfx]
+            [enoki.logging]
+            [enoki.logging-macros :as log]
+            [game.component :as comp]
+            [game.sprite :as sprite])
+  (:use [enoki.core :only [now]]))
 
-^:cljs (ns game.main
-         (:require [clojure.string :as str]
-                   [enoki.asset :as asset]
-                   [enoki.engine :as enoki]
-                   [enoki.entity :as entity]
-                   [enoki.event :as event]
-                   [enoki.graphics :as gfx]
-                   [enoki.logging]
-                   [game.component :as comp]
-                   [game.sprite :as sprite])
-         (:require-macros [enoki.logging-macros :as log])
-         (:use [enoki.core :only [now]])
-         (:use-macros [enoki.cljs-macros :only [double]]))
+#+cljs
+(ns game.main
+  (:require [clojure.string :as str]
+            [enoki.asset :as asset]
+            [enoki.engine :as enoki]
+            [enoki.entity :as entity]
+            [enoki.event :as event]
+            [enoki.graphics :as gfx]
+            [enoki.logging]
+            [game.component :as comp]
+            [game.sprite :as sprite])
+  (:require-macros [enoki.logging-macros :as log])
+  (:use [enoki.core :only [now]])
+  (:use-macros [enoki.cljs-macros :only [double]]))
 
 (def slinky-frames 17)
 

--- a/example/swing/project.clj
+++ b/example/swing/project.clj
@@ -2,7 +2,7 @@
 
   :dependencies [[org.clojure/clojure "1.5.0"]
                  [org.clojure/tools.logging "0.2.4"]
-                 [seesaw "1.4.2"]]
+                 [seesaw "1.4.3"]]
 
   :plugins [[com.keminglabs/cljx "0.3.0"]]
 

--- a/example/swing/project.clj
+++ b/example/swing/project.clj
@@ -4,7 +4,7 @@
                  [org.clojure/tools.logging "0.2.4"]
                  [seesaw "1.4.2"]]
 
-  :plugins [[com.keminglabs/cljx "0.2.1"]]
+  :plugins [[com.keminglabs/cljx "0.3.0"]]
 
   :profiles {:dev {:dependencies [[log4j "1.2.17"]]}}
 
@@ -22,8 +22,7 @@
   :cljx {:builds [{:source-paths ["../common/src/cljx"
                                   "../../common/src/cljx"]
                    :output-path "generated/src"
-                   :include-meta true
-                   :rules cljx.rules/clj-rules}]}
+                   :rules :clj}]}
 
   :aliases {"cibuild" ["do" "cljx," "test"]}
 

--- a/example/web/project.clj
+++ b/example/web/project.clj
@@ -5,7 +5,7 @@
                  [compojure "1.1.3"]
                  [enlive "1.0.0"]]
 
-  :plugins [[com.keminglabs/cljx "0.2.1"]
+  :plugins [[com.keminglabs/cljx "0.3.0"]
             [lein-cljsbuild "0.3.0"]]
 
   :source-paths ["src/clj"]
@@ -18,9 +18,7 @@
                                   ;; are split into separate repos
                                   "../../common/src/cljx"]
                    :output-path "generated/src"
-                   :extension "cljs"
-                   :include-meta true
-                   :rules cljx.rules/cljs-rules}]}
+                   :rules :cljs}]}
 
   :cljsbuild {:builds [{:source-paths ["src/cljs"
                                        "generated/src"

--- a/swing/project.clj
+++ b/swing/project.clj
@@ -6,7 +6,7 @@
                  [org.clojure/tools.logging "0.2.4"]
                  [seesaw "1.4.2"]]
 
-  :plugins [[com.keminglabs/cljx "0.2.1"]]
+  :plugins [[com.keminglabs/cljx "0.3.0"]]
 
   :source-paths ["src"
                  "generated/src"
@@ -17,12 +17,10 @@
 
   :cljx {:builds [{:source-paths ["../common/src/cljx"]
                    :output-path "generated/src"
-                   :include-meta true
-                   :rules cljx.rules/clj-rules}
+                   :rules :clj}
 
                   {:source-paths ["../common/test/cljx"]
                    :output-path "generated/test"
-                   :include-meta true
-                   :rules cljx.rules/clj-rules}]}
+                   :rules :clj}]}
 
   :aliases {"citest" ["do" "cljx," "test"]})

--- a/swing/project.clj
+++ b/swing/project.clj
@@ -4,7 +4,7 @@
 
   :dependencies [[org.clojure/clojure "1.5.0"]
                  [org.clojure/tools.logging "0.2.4"]
-                 [seesaw "1.4.2"]]
+                 [seesaw "1.4.3"]]
 
   :plugins [[com.keminglabs/cljx "0.3.0"]]
 

--- a/web/project.clj
+++ b/web/project.clj
@@ -2,7 +2,7 @@
 
   :dependencies [[org.clojure/clojure "1.5.0"]]
 
-  :plugins [[com.keminglabs/cljx "0.2.1"]
+  :plugins [[com.keminglabs/cljx "0.3.0"]
             [lein-cljsbuild "0.3.0"]]
 
   :profiles {:dev {:dependencies [[com.cemerick/clojurescript.test "0.0.2"]]}}
@@ -15,15 +15,11 @@
   ;; FIXME: update once implementations are separated from core
   :cljx {:builds [{:source-paths ["../common/src/cljx"]
                    :output-path "generated/src"
-                   :extension "cljs"
-                   :include-meta true
-                   :rules cljx.rules/cljs-rules}
+                   :rules :cljs}
 
                   {:source-paths ["../common/test/cljx"]
                    :output-path "generated/test"
-                   :extension "cljs"
-                   :include-meta true
-                   :rules cljx.rules/cljs-rules}]}
+                   :rules :cljs}]}
 
   :cljsbuild {:builds [{:source-paths ["src/cljs"
                                        "generated/src"


### PR DESCRIPTION
Use new `#+clj` / `#+cljs` syntax introduced in cljx 0.3.0.
